### PR TITLE
docs: refresh README (drop architecture wording), add OIDC publish workflow, bump 1.2.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to PyPI
+
+# Publishes the legacy v1 package `idanalyzer` to PyPI when a version tag (v*) is pushed.
+# Uses PyPI Trusted Publishing (OIDC) — no API token required.
+# Configure the trusted publisher on pypi.org for project `idanalyzer`:
+# Owner=idanalyzer, Repo=id-analyzer-python, Workflow=publish.yml, Environment=(blank).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write   # required for OIDC trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 > # ⚠️ DEPRECATED — use the v2 SDK
 > This is the legacy **API v1** Python SDK (PyPI package `idanalyzer`). It targets the
-> older `api.idanalyzer.com` fleet and is no longer actively maintained.
+> older `api.idanalyzer.com` endpoint and is no longer actively maintained.
 >
 > **New projects should use the API v2 SDK:**
 > [`idanalyzer2`](https://pypi.org/project/idanalyzer2/) ·

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.2.2'
+VERSION = '1.2.3'
 DESCRIPTION = 'ID Analyzer API client library, scan and verify global passport, driver license and identification card.'
 
 


### PR DESCRIPTION
Refresh the PyPI README (removed 'fleet' wording), add PyPI OIDC trusted-publishing workflow, bump to 1.2.3 so the registry page picks up the README. No functional changes.